### PR TITLE
Open CORs origins for staging test

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@
 
 Rails.application.config.middleware.insert_before 0, Rack::Cors do
   allow do
-    origins 'localhost:3000', 'hivemindapp.netlify.app'
+    origins '*'
 
     resource '*',
       headers: :any,


### PR DESCRIPTION
Removes limitations on CORs origins -- testing for FE to be able to send mutations (create a post)